### PR TITLE
fix: application identifier prevents build

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "bundle": {
       "active": true,
       "targets": "all",
-      "identifier": "com.tauri.dev",
+      "identifier": "tauri-yew-demo",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",


### PR DESCRIPTION
This fixes an error that occurs when trying to build using a more up to date tauri cli

```
cargo tauri build
       Error You must change the bundle identifier in `tauri.conf.json > tauri > bundle > identifier`. The default value `com.tauri.dev` is not allowed as it must be unique across applications.
```